### PR TITLE
Improve performance of readChar in alt1/ocr

### DIFF
--- a/src/ocr/index.ts
+++ b/src/ocr/index.ts
@@ -503,6 +503,9 @@ export function readChar(buffer: ImageData, font: FontDefinition, col: ColortTri
 				a += 4;
 			}
 			scores[chr].score += Math.max(0, penalty);
+
+			if(!debugobj && scores[chr].score > 400) break // Short circuit the loop as soon as the penalty threshold (400) is reached
+
 			//TODO add compiler flag to this to remove it for performance
 			if (debugimg) { debugimg.setPixel(chrobj.pixels[a], chrobj.pixels[a + 1], [penalty, penalty, penalty, 255]); }
 		}

--- a/src/ocr/index.ts
+++ b/src/ocr/index.ts
@@ -502,7 +502,7 @@ export function readChar(buffer: ImageData, font: FontDefinition, col: ColortTri
 				penalty = canblend(buffer.data[i], buffer.data[i + 1], buffer.data[i + 2], col[0] * lum, col[1] * lum, col[2] * lum, chrobj.pixels[a + 2] / 255);
 				a += 4;
 			}
-			scores[chr].score += Math.max(0, penalty);
+			scores[chr].score += penalty;
 
 			if(!debugobj && scores[chr].score > 400) break // Short circuit the loop as soon as the penalty threshold (400) is reached
 

--- a/src/ocr/index.ts
+++ b/src/ocr/index.ts
@@ -518,7 +518,7 @@ export function readChar(buffer: ImageData, font: FontDefinition, col: ColortTri
 		scores.slice(0, 5).forEach(q => console.log(q.chr.chr, q.score.toFixed(3), q.sizescore.toFixed(3)));
 	}
 
-	let winchr: (typeof candidate_scores)[number] | null = null
+	let winchr: (typeof scores)[number] | null = null
 
 	for (const chrscore of scores) {
 		if (!winchr || (chrscore && chrscore.sizescore < winchr.sizescore)) winchr = chrscore

--- a/src/ocr/index.ts
+++ b/src/ocr/index.ts
@@ -479,10 +479,10 @@ export function readChar(buffer: ImageData, font: FontDefinition, col: ColortTri
 
 	//====== start reading the char ======
 	var scores: { score: number, sizescore: number, chr: Charinfo }[] = [];
-	for (var chr = 0; chr < font.chars.length; chr++) {
+	charloop: for (var chr = 0; chr < font.chars.length; chr++) {
 		var chrobj = font.chars[chr];
 		if (chrobj.secondary && !allowSecondary) { continue; }
-		scores[chr] = { score: 0, sizescore: 0, chr: chrobj };
+		const scoreobj = { score: 0, sizescore: 0, chr: chrobj };
 		var chrx = (backwards ? x - chrobj.width : x);
 
 
@@ -502,15 +502,19 @@ export function readChar(buffer: ImageData, font: FontDefinition, col: ColortTri
 				penalty = canblend(buffer.data[i], buffer.data[i + 1], buffer.data[i + 2], col[0] * lum, col[1] * lum, col[2] * lum, chrobj.pixels[a + 2] / 255);
 				a += 4;
 			}
-			scores[chr].score += penalty;
+			scoreobj.score += penalty;
 
-			if(!debugobj && scores[chr].score > 400) break // Short circuit the loop as soon as the penalty threshold (400) is reached
+			// Short circuit the loop as soon as the penalty threshold (400) is reached
+			if (!debugobj && scoreobj.score > 400) {
+				continue charloop; 
+			}
 
 			//TODO add compiler flag to this to remove it for performance
 			if (debugimg) { debugimg.setPixel(chrobj.pixels[a], chrobj.pixels[a + 1], [penalty, penalty, penalty, 255]); }
 		}
-		scores[chr].sizescore = scores[chr].score - chrobj.bonus;
-		if (debugobj) { debugobj.push({ chr: chrobj.chr, score: scores[chr].sizescore, rawscore: scores[chr].score, img: debugimg! }); }
+		scoreobj.sizescore = scoreobj.score - chrobj.bonus;
+		if (debugobj) { debugobj.push({ chr: chrobj.chr, score: scoreobj.sizescore, rawscore: scoreobj.score, img: debugimg! }); }
+		scores.push(scoreobj)
 	}
 
 	if (debug.printcharscores) {

--- a/src/ocr/index.ts
+++ b/src/ocr/index.ts
@@ -521,9 +521,9 @@ export function readChar(buffer: ImageData, font: FontDefinition, col: ColortTri
 	let winchr: (typeof candidate_scores)[number] | null = null
 
 	for (const chrscore of scores) {
-		if(!winchr || chrscore.sizescore < winchr.sizescore) winchr = chrscore
+		if (!winchr || (chrscore && chrscore.sizescore < winchr.sizescore)) winchr = chrscore
 	}
-	
+
 	if (!winchr || winchr.score > 400) { return null; }
 
 	return { chr: winchr.chr.chr, basechar: winchr.chr, x: x + shiftx, y: y + shifty, score: winchr.score, sizescore: winchr.sizescore };

--- a/src/ocr/index.ts
+++ b/src/ocr/index.ts
@@ -513,13 +513,17 @@ export function readChar(buffer: ImageData, font: FontDefinition, col: ColortTri
 		if (debugobj) { debugobj.push({ chr: chrobj.chr, score: scores[chr].sizescore, rawscore: scores[chr].score, img: debugimg! }); }
 	}
 
-	scores.sort((a, b) => a.sizescore - b.sizescore);
-
 	if (debug.printcharscores) {
+		scores.sort((a, b) => a.sizescore - b.sizescore);
 		scores.slice(0, 5).forEach(q => console.log(q.chr.chr, q.score.toFixed(3), q.sizescore.toFixed(3)));
 	}
 
-	var winchr = scores[0];
+	let winchr: (typeof candidate_scores)[number] | null = null
+
+	for (const chrscore of scores) {
+		if(!winchr || chrscore.sizescore < winchr.sizescore) winchr = chrscore
+	}
+	
 	if (!winchr || winchr.score > 400) { return null; }
 
 	return { chr: winchr.chr.chr, basechar: winchr.chr, x: x + shiftx, y: y + shifty, score: winchr.score, sizescore: winchr.sizescore };


### PR DESCRIPTION
I noticed `readChar` does two things that are detrimental to performance:

1. It continues to check pixels for a character even if that character already reached an accumulated penalty of over 400, at which point it is no longer considered as a result anyway.
2. It sorts the entire array of scores to find the best one.

This pull request fixes both of these issues. The pixel loop is short circuited as soon as the score reaches 400 (unless debugging is enabled) and the array is checked linearly for the best score. It's only sorted when required for the debugging option.

I also removed the `Math.max` call since `unblend` already does this, so `penalty` is always positive.

I did not benchmark `readChar` in isolation so these numbers are not very scientific, but combined with some image data transmission from Alt1 to JS I got a speedup of around a 100% to the point where the bottleneck was a combination of the data transmission (known problem) and `getChatColor` (because I check for all colors).

Locally I did a larger scale refactor of `readChar` and `getChatColor`, but I didn't want to mess with the debug options and my `getChatColor` is barely tested, so this pull request is just a condensed version of that